### PR TITLE
Review/dynamic replacement

### DIFF
--- a/include/dynamic_replacement/CMakeLists.txt
+++ b/include/dynamic_replacement/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(CMAKE_CXX_STANDARD 17)
+
+enable_testing()
+
+add_executable(test_compute_node_connect_and_blanch_num test_compute_node_connect_and_blanch_num.cpp)
+add_test(test_compute_node_connect_and_blanch_num test_compute_node_connect_and_blanch_num)

--- a/include/dynamic_replacement/map_dr.hpp
+++ b/include/dynamic_replacement/map_dr.hpp
@@ -13,6 +13,9 @@
 
 namespace poplar {
 
+static std::map<int, int> cnt_hash;
+static uint64_t all_cnt = 0;
+
 // This class implements an updatable associative array whose keys are strings.
 // The data structure is based on a dynamic path-decomposed trie described in the following paper,
 // - "Dynamic Path-Decomposed Tries" available at https://arxiv.org/abs/1906.06015.

--- a/include/dynamic_replacement/plain_bonsa_trie_dr.hpp
+++ b/include/dynamic_replacement/plain_bonsa_trie_dr.hpp
@@ -11,6 +11,9 @@
 
 namespace poplar {
 
+static std::map<int, int> cnt_linear_proving;
+static uint64_t cnt_linear_proving_all = 0;
+
 template <uint32_t MaxFactor = 90, typename Hasher = hash::vigna_hasher>
 class plain_bonsai_trie_dr {
   private:

--- a/include/dynamic_replacement/test_compute_node_connect_and_blanch_num.cpp
+++ b/include/dynamic_replacement/test_compute_node_connect_and_blanch_num.cpp
@@ -1,0 +1,104 @@
+#include "map_dr.hpp"
+#include "plain_bonsa_trie_dr.hpp"
+#include "plain_bonsai_nlm_dr.hpp"
+#include <cstdio>
+#include <vector>
+#include <string>
+
+using namespace poplar;
+
+int main() {
+  std::vector<std::string> keys = {
+      "aaaaaaaaa",
+      "aaaaaabbb",
+      "aaaaaaccc",
+      "aaabbbbbb",
+      "aaabbbccc",
+      "bbbbbbbbb",
+      "bbbcccccc",
+      "bbbccccccddd"
+  };
+  map_dr<plain_bonsai_trie_dr<>, plain_bonsai_nlm_dr<int>> mp(8);
+  for (auto it = keys.rbegin(); it != keys.rend(); ++it) {
+    mp.update(*it);
+  }
+  std::vector<std::vector<std::pair<uint64_t, uint64_t>>> children;
+  std::vector<uint64_t> blanch_num_except_zero;
+  std::vector<uint64_t> cnt_leaf_per_node;
+  mp.compute_node_connect_and_blanch_num(children, blanch_num_except_zero, cnt_leaf_per_node);
+
+  auto show_internal = [&]() {
+    std::cerr << "children = {" << std::endl;
+    for (size_t i = 0; i < children.size(); ++i) {
+      auto& cl = children[i];
+      if (cl.empty()) continue;
+      std::cerr << "\t["<<i<<"] ""{" << std::endl << "\t\t";
+      for (auto c : cl) {
+        std::cerr << "{ " << c.first << ", " << c.second << " }," ;
+      }
+      std::cerr << std::endl << "\t}," << std::endl;
+    }
+    std::cerr << "}" << std::endl;
+    std::cerr << "blanch_num_except_zero = {" << std::endl;
+    for (size_t i = 0; i < blanch_num_except_zero.size(); ++i) {
+      auto v = blanch_num_except_zero[i];
+      if (v == 0) continue;
+      std::cerr << "\t[" << i << "] " << v << ", " << std::endl;
+    }
+    std::cerr << "}" << std::endl;
+    std::cerr << "cnt_leaf_per_node = {" << std::endl;
+    for (size_t i = 0; i < cnt_leaf_per_node.size(); ++i) {
+      auto v = cnt_leaf_per_node[i];
+      if (v == 0) continue;
+      std::cerr << "\t[" << i << "] " << v << ", " << std::endl;
+    }
+    std::cerr << "}" << std::endl;
+  };
+
+  std::vector<std::pair<size_t, std::vector<std::pair<uint64_t,uint64_t>>>> children_exp {
+      {1, {{ 9, 22042 },{ 0, 38070 },{ 3, 38084 }}},
+        {1920, {
+                { 2, 16923 },{ 2, 42257 },
+        }},
+        {38070, {
+                { 2, 1920 },{ 5, 51392 },
+        }},
+  };
+  std::vector<std::pair<size_t,uint64_t>> blanch_num_except_zero_exp {
+    {0, 8},
+    {1, 2},
+    {1920, 2},
+    {38070, 4},
+  };
+  std::vector<std::pair<size_t,uint64_t>> cnt_leaf_per_node_exp {
+    {0, 8},
+    {1, 8},
+    {1920, 3},
+    {16923, 1},
+    {22042, 1},
+    {38070, 5},
+    {38084, 1},
+    {42257, 1},
+    {51392, 1},
+  };
+
+  for (auto [i,cle] : children_exp) {
+    if (cle != children[i]) {
+      show_internal();
+      return EXIT_FAILURE;
+    }
+  }
+  for (auto [i,v] : blanch_num_except_zero_exp) {
+    if (v != blanch_num_except_zero[i]) {
+      show_internal();
+      return EXIT_FAILURE;
+    }
+  }
+  for (auto [i,v] : cnt_leaf_per_node_exp) {
+    if (v != cnt_leaf_per_node[i]) {
+      show_internal();
+      return EXIT_FAILURE;
+    }
+  }
+  std::cout << "OK" << std::endl;
+}


### PR DESCRIPTION
## 更新内容
- map_dr::compute_node_connect_and_blanch_num のテストコードを追加
- メモリアロケーションの最適化

## 今後の改善点
おそらく遅い原因は、深さ(分岐位置)に対する子の葉の数の累積和を計算する部分です。
例えば、分岐位置の多重集合が`M={0,2,5,12,30,5}`というノードがあったときに、今のアルゴリズムではO(max(M))かかっています。
これをO(|M|)に出来れば早くなりそうです。

一言で言えば、**分岐位置を座標圧縮**して、分岐数だけのメモリを確保して処理して下さい。

## 補足
require_centroid_path_order_and_insert_dictionaly のテストコードは書いてないので、自身で用意してから作業することをおすすめします。